### PR TITLE
Autocomplete patch for issue #14

### DIFF
--- a/Support/utils.clj
+++ b/Support/utils.clj
@@ -173,7 +173,7 @@
       (let [ch (.charAt line index)]
         #_(println "index:" index "char:" ch"<br>")
         (cond 
-            (zero? index) (.trim (.substring line 0 (inc stop)))
+            (neg? index) (.trim (.substring line 0 (inc stop)))
             (or (nil? ch) (not (symbol-char? (.charAt line index))))                                 
               (.trim (.substring line (inc index) (inc stop)))
             :else (recur (dec index)))))))


### PR DESCRIPTION
The problem was in utils.clj and was not related to the parentheses but that when in column 0 there was not made any check on the character.
