### PR TITLE
Issue 13

### DIFF
--- a/Support/bin/load_file.clj
+++ b/Support/bin/load_file.clj
@@ -1,9 +1,11 @@
 #!/usr/bin/env cake run
 (require '[clojure.java.io :as io])
+           
 (load-file (str (io/file (cake/*env* "TM_BUNDLE_SUPPORT") "utils.clj")))
-(in-ns 'textmate)
+
+(in-ns 'user)
 (let [tm-filepath (cake/*env* "TM_FILEPATH")]
   (when (not (= tm-filepath ""))
-    (attempt
+    (textmate/attempt
       (load-file tm-filepath)
       (clojure.core/println "<pre>Loading finished.</pre>"))))

--- a/Support/utils.clj
+++ b/Support/utils.clj
@@ -129,7 +129,7 @@
   [& forms]
   `(let [old-ns# *ns*]
     (enter-file-ns)
-    (let [r# ~@forms]
+    (let [r# (eval ~@forms)]
       (enter-ns (-> old-ns# str symbol))
       r#)))
 
@@ -256,7 +256,6 @@
       "<pre>"
       (textmate/attempt
         (-> form
-            clojure.core/eval
             textmate/eval-in-file-ns
             textmate/ppstr-nil
             textmate/htmlize

--- a/Support/utils.clj
+++ b/Support/utils.clj
@@ -113,23 +113,14 @@
   (let [ns (file-ns)]
     (enter-ns ns)))
 
-(defmacro eval-in-ns
-  ""
-  [the-ns & forms]
-  `(let [old-ns# *ns*]
-    (enter-ns ~the-ns)
-    (let [r# ~@forms]
-      (enter-ns (-> old-ns# str symbol))
-      r#)))
-
 (defmacro eval-in-file-ns
   "For the current file, enter the ns (if any)
   and evaluate the form in that ns, then pop
   back up to the original ns"
-  [& forms]
+  [form]
   `(let [old-ns# *ns*]
     (enter-file-ns)
-    (let [r# (eval ~@forms)]
+    (let [r# (eval ~form)]
       (enter-ns (-> old-ns# str symbol))
       r#)))
 


### PR DESCRIPTION
- In display-form-eval, the  clojure.core/eval call that was done should be done after the namespace is changed, so I have moved it inside the macro eval-in-file-ns.
- Load was done in namespace textmate. Now its done by default in namespace user (for those files which does not have ns or in-ns). If the file has an explicit ns or in-ns, load-file will take care of it.
- I have done two clean-ups: deleting macro eval-in-ns which is never used and renaming the parameter to eval-in-file-ns from 'forms' to 'form' (and removing the & in the parameters definition) because we always pass only one form.
- I have some questions about what it is considered proper functioning:
  - If I have a file with this content:
    
    ```
    (def name 12)
    (ns myns)
    (def name 15)
    ```
  
  and load it, user/name is defined with value 12 and myns/name with value 15. I think this is right.
  - But if I put the caret after the first line and do ^X, the expression gets evaluated in myns (because the namespace assigned to the whole file does not take caret's position into account). 
    Is this the way it is suppose to work or one has to find the last ns or in-ns before the caret?
  - Command-Shift-X (eval) now it evaluates the first one in selection.
    Should be capable of evaluating more than one sexpr (and returning the value of the last one)? 
  - Eval and eval-last-sexpr behaviour differently. For instance, if I append name to the file, that is:
    
    ```
    (def name 12)
    (ns myns)
    (def name 15)
    name
    ```
  
  and I put the cursos after name, if I do ^X I get #'myns/name as result, but if I select name and do Command-Shift-X I get 15.
  Is this the way it is supposed to be?
