### PR TITLE
Accepts both #^ and ^ to signal metadata (closes issue 26)

### DIFF
--- a/Syntaxes/Clojure.tmLanguage
+++ b/Syntaxes/Clojure.tmLanguage
@@ -1895,7 +1895,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>#\^{</string>
+					<string>#?\^{</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>0</key>
@@ -1926,7 +1926,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>#\^"</string>
+					<string>#?\^"</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>0</key>
@@ -1963,7 +1963,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(#\^)([a-zA-Z+!\-_?0-9*/.$=]+)</string>
+					<string>(#?\^)([a-zA-Z+!\-_?0-9*/.$=]+)</string>
 					<key>name</key>
 					<string>punctuation.metadata.class.clojure</string>
 				</dict>


### PR DESCRIPTION
Making the # optional in the combination #^ as metadata reading macro I think closes issue-26 allowing type hints using this notation.

I'm not sure of the path, because I don't use type hints very much in my code.

Best regards,

Juan Manuel
