### PR TITLE
Resolved "Load File" key binding clash

### DIFF
--- a/Commands/Compile File.tmCommand
+++ b/Commands/Compile File.tmCommand
@@ -18,7 +18,7 @@ load_file.clj</string>
 	<key>input</key>
 	<string>none</string>
 	<key>keyEquivalent</key>
-	<string>@L</string>
+	<string>^l</string>
 	<key>name</key>
 	<string>Load File</string>
 	<key>output</key>

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Create a source file in your <code>src</code> directory called <code>hello_world
   (println "Hello world!"))
 </pre>
 
-Type <code>Command-Shift-L</code>. This will load your file. You now have a function that you can run. One way is by typing the following and <code>Control-X</code> in the position indicated:
+Type <code>Control-L</code>. This will load your file. You now have a function that you can run. One way is by typing the following and <code>Control-X</code> in the position indicated:
 
 <pre>
 (hello-world)


### PR DESCRIPTION
Let's make the key binding for the **Load File** command **Control-L**. The previous binding of **Command-Shift-L** overrode TextMate's built in menu item **Edit > Select > Line**.
